### PR TITLE
fix: handle script / dir name collisions correctly

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -93,7 +93,7 @@ fn trim_supported_extensions(name: &std::string::String) -> std::string::String 
                 .to_string();
         }
     }
-    return name.to_string();
+    name.to_string()
 }
 
 /// Builds a list of commands from a directory

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -91,9 +91,9 @@ pub fn parse_command_metadata(path: &Path) -> CommandMetadata {
                             None
                         };
                         metadata.args.push(Arg {
-                            name: name,
+                            name,
                             description: desc,
-                            default: default,
+                            default,
                         });
                     }
                 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -198,12 +198,12 @@ mod tests {
 
         // Test arguments
         assert_eq!(metadata.args.len(), 2);
-        let input_arg= &metadata.args[0];
+        let input_arg = &metadata.args[0];
         assert_eq!(input_arg.name, "input");
         assert_eq!(input_arg.description, "Input file path");
         assert!(input_arg.default.is_none());
 
-        let output_arg= &metadata.args[1];
+        let output_arg = &metadata.args[1];
         assert_eq!(output_arg.name, "output");
         assert_eq!(output_arg.description, "Output file path");
         assert_eq!(output_arg.default.as_deref(), Some("output.txt"));

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,9 +5,15 @@ use std::path::Path;
 #[derive(Default)]
 pub struct CommandMetadata {
     pub description: String,
-    pub args: Vec<(String, String, Option<String>)>, // (name, description, default)
+    pub args: Vec<Arg>,                      // (name, description, default)
     pub flags: Vec<Flag>, // (name, description, required, is_bool, default, options)
     pub catch_all: Option<(String, String)>, // (name, description) for catching remaining arguments
+}
+
+pub struct Arg {
+    pub name: String,
+    pub description: String,
+    pub default: Option<String>,
 }
 
 pub struct Flag {
@@ -84,7 +90,11 @@ pub fn parse_command_metadata(path: &Path) -> CommandMetadata {
                         } else {
                             None
                         };
-                        metadata.args.push((name, desc, default));
+                        metadata.args.push(Arg {
+                            name: name,
+                            description: desc,
+                            default: default,
+                        });
                     }
                 }
             }
@@ -188,15 +198,15 @@ mod tests {
 
         // Test arguments
         assert_eq!(metadata.args.len(), 2);
-        let (input_name, input_desc, input_default) = &metadata.args[0];
-        assert_eq!(input_name, "input");
-        assert_eq!(input_desc, "Input file path");
-        assert!(input_default.is_none());
+        let input_arg= &metadata.args[0];
+        assert_eq!(input_arg.name, "input");
+        assert_eq!(input_arg.description, "Input file path");
+        assert!(input_arg.default.is_none());
 
-        let (output_name, output_desc, output_default) = &metadata.args[1];
-        assert_eq!(output_name, "output");
-        assert_eq!(output_desc, "Output file path");
-        assert_eq!(output_default.as_deref(), Some("output.txt"));
+        let output_arg= &metadata.args[1];
+        assert_eq!(output_arg.name, "output");
+        assert_eq!(output_arg.description, "Output file path");
+        assert_eq!(output_arg.default.as_deref(), Some("output.txt"));
 
         // Test catch-all argument
         assert!(metadata.catch_all.is_some());

--- a/src/script.rs
+++ b/src/script.rs
@@ -30,11 +30,11 @@ pub fn execute_script(script_path: &Path, matches: &ArgMatches) -> std::io::Resu
     let metadata = parse_command_metadata(script_path);
 
     // Add positional arguments as environment variables
-    for (arg_name, _, default) in metadata.args {
-        let env_name = format!("CLI_{}", arg_name.replace('-', "_").to_uppercase());
-        let value = if let Some(value) = matches.get_one::<String>(&arg_name) {
+    for arg in metadata.args {
+        let env_name = format!("CLI_{}", arg.name.replace('-', "_").to_uppercase());
+        let value = if let Some(value) = matches.get_one::<String>(&arg.name) {
             value.as_str()
-        } else if let Some(ref default_value) = default {
+        } else if let Some(ref default_value) = arg.default {
             default_value.as_str()
         } else {
             ""


### PR DESCRIPTION
If a script command and a subcommand would produce the same name, we have to preserve the extension on the script name for the script command.