### PR TITLE
chore: expose shutl-verbose flag for all scripts

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -19,8 +19,7 @@ fn build_script_command(name: String, path: &Path) -> CommandWithPath {
     let metadata = parse_command_metadata(path);
     let mut cmd = Command::new(&name).disable_help_subcommand(true).arg(
         Arg::new("shutlverboseid")
-            .help("Enable verbose output")
-            .hide(true)
+            .help("Print verbose information about the command")
             .long("shutl-verbose")
             .action(clap::ArgAction::SetTrue),
     );

--- a/src/script.rs
+++ b/src/script.rs
@@ -62,6 +62,8 @@ pub fn execute_script(script_path: &Path, matches: &ArgMatches) -> std::io::Resu
                 value.unwrap().to_str().unwrap()
             );
         }
+
+        println!("Command: {:?}", command.get_program());
     }
 
     // debug the command env


### PR DESCRIPTION
the `--shutl-verbose` flag exists for all scripts, but is was hidden.